### PR TITLE
Create skeleton MCP server project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,17 @@
+node_modules/
+dist/
+.env
+.DS_Store
+coverage/
+.tmp/
+.nyc_output/
+# Logs
+logs/
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+.pnpm-debug.log*
+# Editor directories
+.vscode/
+.idea/

--- a/README.md
+++ b/README.md
@@ -1,0 +1,103 @@
+# FreshDesk MCP Server Skeleton
+
+This repository provides a graduate-level yet approachable starting point for building an AI-assisted [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) server that triages FreshDesk-style support tickets. The codebase demonstrates how to structure an MCP server that orchestrates tools, workflows, and knowledge assets so you can showcase proficiency with AI tooling and the MCP ecosystem.
+
+## Why this project?
+
+The project is framed as an **AI augmentation layer for FreshDesk** that can:
+
+- Retrieve contextual knowledge base articles for a ticket.
+- Inspect or update offline ticket data via MCP tools.
+- Orchestrate end-to-end triage workflows that combine tool calls and AI reasoning.
+- Provide governance hooks for auditability and safe automation.
+
+This makes it a compelling portfolio piece because it blends MCP concepts, AI tooling, and practical automation for customer support operations.
+
+## Repository layout
+
+```
+.
+├── config/                # Project configuration consumed by the runtime
+├── data/                  # Sample tickets and knowledge base content
+├── docs/                  # Architectural notes and design prompts
+├── src/                   # TypeScript source code for the MCP server skeleton
+│   ├── config/            # Configuration loader and validation
+│   ├── domain/            # Core domain models shared across the app
+│   ├── server/            # Server bootstrap logic and MCP integration hook
+│   ├── services/          # Data access layers for tickets and knowledge articles
+│   ├── tools/             # Tool definitions exposed over MCP
+│   ├── workflows/         # Workflow orchestration primitives
+│   └── utils/             # Cross-cutting helpers (e.g., logging)
+├── package.json           # npm scripts and dependencies
+└── tsconfig.json          # TypeScript compiler configuration
+```
+
+## Quick start
+
+1. **Install dependencies**
+
+   ```bash
+   npm install
+   ```
+
+2. **Run the TypeScript build**
+
+   ```bash
+   npm run build
+   ```
+
+3. **Start the lightweight runtime**
+
+   ```bash
+   node dist/index.js
+   ```
+
+   The default bootstrap logs available tools and workflows. To execute the demo workflow against a specific ticket, set environment variables:
+
+   ```bash
+   DEMO_WORKFLOW=ticket_triage DEMO_TICKET_ID=TCK-1001 node dist/index.js
+   ```
+
+4. **Connect via MCP tooling (optional)**
+
+   The runtime detects the presence of `@modelcontextprotocol/sdk`. After installing the SDK, extend `src/server/createServer.ts` to register the `toolRegistry` and `workflowRegistry` with the MCP server transport of your choice (e.g., stdio, WebSocket).
+
+## Suggested implementation roadmap
+
+The skeleton emphasises patterns you can expand into a full graduate-level project:
+
+1. **Integrate an actual MCP transport**
+   - Use `@modelcontextprotocol/sdk` to expose the registered tools over stdio or WebSocket.
+   - Implement structured tool schemas so MCP clients (such as IDE extensions) can discover capabilities.
+
+2. **Add AI reasoning loops**
+   - Introduce an LLM client (OpenAI, Anthropic, Azure, etc.) that interprets ticket context, calls MCP tools, and drafts responses.
+   - Store prompts and chain-of-thought outputs to support reproducibility and research.
+
+3. **Implement advanced workflows**
+   - Expand beyond `ticket_triage` to include quality audits, escalation detection, or automated post-mortem summaries.
+   - Add human-in-the-loop checkpoints controlled via the `governance` configuration.
+
+4. **Observability and evaluation**
+   - Capture workflow metrics, tool invocation traces, and success criteria.
+   - Build evaluation harnesses that replay historical tickets to benchmark automation quality.
+
+5. **Deployability**
+   - Containerise the runtime with Docker.
+   - Provide Terraform or pulumi scripts for cloud deployment if targeting production scenarios.
+
+## Customisation tips
+
+- Modify `config/project.config.json` to point at real ticket stores or knowledge bases.
+- Extend the `ToolRegistry` with domain-specific tools—e.g., FreshDesk API clients, CRM lookups, or internal runbooks.
+- Replace the placeholder recommendation logic in `src/workflows/triageWorkflow.ts` with AI-generated action plans.
+- Wire in persistence layers (PostgreSQL, Redis) and toggle `allowTicketUpdates` when you are ready to make stateful changes.
+- Use the `docs/architecture.md` file as a living design document for thesis-style documentation.
+
+## Testing
+
+The project ships with a Vitest test runner stub. Add suites under `tests/` (create the folder) and update `npm test` once you implement business logic. Static validation via ESLint can be enabled through the provided configuration.
+
+## License
+
+[MIT](./LICENSE)

--- a/config/project.config.json
+++ b/config/project.config.json
@@ -1,0 +1,20 @@
+{
+  "server": {
+    "name": "freshdesk-mcp-skeleton",
+    "description": "AI-assisted FreshDesk triage server built with the Model Context Protocol",
+    "port": 8071
+  },
+  "aiProviders": {
+    "defaultModel": "gpt-4.1-mini",
+    "fallbackModel": "gpt-4o-mini",
+    "temperature": 0.2
+  },
+  "dataPaths": {
+    "tickets": "data/sampleTickets.json",
+    "knowledgeBase": "data/knowledgeBase/articles.json"
+  },
+  "governance": {
+    "allowTicketUpdates": false,
+    "auditLogPath": "data/audit-log.json"
+  }
+}

--- a/data/knowledgeBase/articles.json
+++ b/data/knowledgeBase/articles.json
@@ -1,0 +1,26 @@
+[
+  {
+    "id": "KB-001",
+    "title": "Resolve blank FreshDesk widget screens in Safari",
+    "tags": ["widget", "safari", "troubleshooting"],
+    "excerpt": "Steps to resolve CSP issues causing the messenger widget to render blank in Safari.",
+    "url": "https://example.com/docs/freshdesk-widget-safari",
+    "body": "Confirm the Content-Security-Policy allows https://widget.freshdesk.com. Clear the service worker cache and upgrade the widget SDK to at least v3.2.1."
+  },
+  {
+    "id": "KB-002",
+    "title": "Rerouting VIP automation flows",
+    "tags": ["automation", "vip", "routing"],
+    "excerpt": "Update automation rules to ensure enterprise queue assignment for VIP contacts.",
+    "url": "https://example.com/docs/vip-routing",
+    "body": "Add a condition matching the billing form source, then set the 'Assign to group' action to the enterprise queue. Validate with a sandbox ticket before publishing."
+  },
+  {
+    "id": "KB-003",
+    "title": "Export quarterly analytics from FreshDesk",
+    "tags": ["reporting", "analytics", "exports"],
+    "excerpt": "Export ticket analytics for financial reporting.",
+    "url": "https://example.com/docs/analytics-export",
+    "body": "Navigate to Analytics > Ticket Volume, select the desired quarter, and click 'Schedule Export'. Choose CSV and include CSAT metrics to align with finance requirements."
+  }
+]

--- a/data/sampleTickets.json
+++ b/data/sampleTickets.json
@@ -1,0 +1,32 @@
+[
+  {
+    "id": "TCK-1001",
+    "subject": "FreshDesk widget fails to load in production",
+    "description": "Customers report a blank screen when opening the FreshDesk messenger widget on Safari 17.",
+    "status": "open",
+    "priority": "high",
+    "productArea": "widgets",
+    "createdAt": "2024-05-08T09:15:00.000Z",
+    "updatedAt": "2024-05-08T09:15:00.000Z"
+  },
+  {
+    "id": "TCK-1002",
+    "subject": "Automation rule misroutes VIP tickets",
+    "description": "VIP tickets created via the billing form are not assigned to the enterprise queue as expected.",
+    "status": "pending",
+    "priority": "urgent",
+    "productArea": "automations",
+    "createdAt": "2024-05-07T14:02:00.000Z",
+    "updatedAt": "2024-05-08T07:41:00.000Z"
+  },
+  {
+    "id": "TCK-1003",
+    "subject": "Request for quarterly analytics export",
+    "description": "Finance needs a CSV export of support interactions for Q1 with customer satisfaction metrics.",
+    "status": "resolved",
+    "priority": "medium",
+    "productArea": "reporting",
+    "createdAt": "2024-05-01T10:31:00.000Z",
+    "updatedAt": "2024-05-05T19:11:00.000Z"
+  }
+]

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,39 @@
+# Architecture Notes
+
+This document captures the reasoning behind the skeleton architecture and provides prompts you can expand into a thesis-style project report.
+
+## High-level design
+
+- **Entry point (`src/index.ts`)**: Loads configuration, builds registries, and boots the server runtime. It is the integration point for MCP transports.
+- **Configuration (`src/config/`)**: Validates project configuration via Zod, ensuring deterministic behaviour across environments.
+- **Domain models (`src/domain/`)**: Centralised schemas for tickets, knowledge articles, and workflows. Shared Zod schemas make it easier to reuse validation in tools and services.
+- **Services (`src/services/`)**: Data access layer for tickets and knowledge articles. Currently file-backed but can be replaced with API or database clients.
+- **Tools (`src/tools/`)**: Encapsulate functionality exposed to MCP clients. Tools consume services and return typed responses that can be fed into AI agents.
+- **Workflows (`src/workflows/`)**: Define multi-step automation paths that invoke tools in sequence. The registry exposes a `run` method that higher-level orchestrators (e.g., an agent loop) can call.
+- **Server runtime (`src/server/createServer.ts`)**: Provides lifecycle hooks (`start`, `stop`, `runWorkflow`) and a placeholder `attemptSdkBootstrap` helper so you can connect the skeleton to a real MCP transport later.
+
+## Extension prompts
+
+Use the following prompts to guide deeper exploration:
+
+1. **MCP transport integration**
+   - Evaluate stdio vs WebSocket transports for your deployment environment.
+   - Design authentication and rate-limiting strategies if the server is exposed externally.
+
+2. **AI orchestration layer**
+   - Specify how an LLM agent should decide which tools to call.
+   - Describe prompt templates and memory strategies for long-running investigations.
+
+3. **Data governance**
+   - Determine when `allowTicketUpdates` should be toggled on and how audit logs should be structured.
+   - Explore redaction pipelines to remove sensitive data before AI processing.
+
+4. **Evaluation methodology**
+   - Outline offline evaluation suites for accuracy, latency, and safety.
+   - Consider user-in-the-loop experiments to measure operator satisfaction.
+
+5. **Security considerations**
+   - Document the threat model for exposing internal tools via MCP.
+   - Recommend secrets management practices and rotation cadences.
+
+Keep this document updated as you iterate. It becomes a valuable artifact when presenting the project to academic or professional audiences.

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,32 @@
+import js from "@eslint/js";
+import tsParser from "@typescript-eslint/parser";
+import tsPlugin from "@typescript-eslint/eslint-plugin";
+
+export default [
+  js.configs.recommended,
+  {
+    files: ["**/*.ts"],
+    languageOptions: {
+      parser: tsParser,
+      parserOptions: {
+        ecmaVersion: 2022,
+        sourceType: "module",
+        project: false,
+      },
+    },
+    plugins: {
+      "@typescript-eslint": tsPlugin,
+    },
+    rules: {
+      "@typescript-eslint/explicit-function-return-type": "off",
+      "@typescript-eslint/no-floating-promises": "error",
+      "import/order": [
+        "warn",
+        {
+          "newlines-between": "always",
+          alphabetize: { order: "asc" },
+        },
+      ],
+    },
+  },
+];

--- a/package.json
+++ b/package.json
@@ -1,0 +1,41 @@
+{
+  "name": "mcp-freshdesk",
+  "version": "0.1.0",
+  "description": "Graduate-level skeleton project demonstrating a Model Context Protocol server integrating AI tooling for helpdesk automation.",
+  "license": "MIT",
+  "type": "module",
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "start": "node dist/index.js",
+    "dev": "tsx watch src/index.ts",
+    "lint": "eslint \"src/**/*.ts\"",
+    "test": "vitest"
+  },
+  "keywords": [
+    "mcp",
+    "ai",
+    "freshdesk",
+    "automation",
+    "typescript"
+  ],
+  "author": "",
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^0.3.0",
+    "dotenv": "^16.4.5",
+    "pino": "^8.19.0",
+    "zod": "^3.23.8"
+  },
+  "devDependencies": {
+    "@types/node": "^20.11.24",
+    "@eslint/js": "^8.57.0",
+    "@typescript-eslint/eslint-plugin": "^7.7.0",
+    "@typescript-eslint/parser": "^7.7.0",
+    "eslint": "^8.57.0",
+    "eslint-config-prettier": "^9.1.0",
+    "eslint-plugin-import": "^2.29.1",
+    "pino-pretty": "^11.0.0",
+    "tsx": "^4.7.1",
+    "typescript": "^5.4.2",
+    "vitest": "^1.3.1"
+  }
+}

--- a/src/config/projectConfig.ts
+++ b/src/config/projectConfig.ts
@@ -1,0 +1,20 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { ProjectConfig, ProjectConfigSchema } from "../domain/types.js";
+import { logger } from "../utils/logger.js";
+
+const CONFIG_PATH = resolve(process.cwd(), "config", "project.config.json");
+
+export function loadProjectConfig(customPath?: string): ProjectConfig {
+  const pathToRead = customPath ? resolve(process.cwd(), customPath) : CONFIG_PATH;
+  const rawFile = readFileSync(pathToRead, "utf-8");
+  const parsed = JSON.parse(rawFile) as unknown;
+  const result = ProjectConfigSchema.safeParse(parsed);
+
+  if (!result.success) {
+    logger.error({ issues: result.error.issues }, "Invalid project configuration");
+    throw new Error("Configuration validation failed");
+  }
+
+  return result.data;
+}

--- a/src/domain/types.ts
+++ b/src/domain/types.ts
@@ -1,0 +1,87 @@
+import { z } from "zod";
+
+export const TicketSchema = z.object({
+  id: z.string(),
+  subject: z.string(),
+  description: z.string(),
+  status: z.enum(["open", "pending", "resolved", "closed"]).default("open"),
+  priority: z.enum(["low", "medium", "high", "urgent"]).default("medium"),
+  productArea: z.string().optional(),
+  createdAt: z.string().datetime().optional(),
+  updatedAt: z.string().datetime().optional(),
+});
+
+export type Ticket = z.infer<typeof TicketSchema>;
+
+export const KnowledgeArticleSchema = z.object({
+  id: z.string(),
+  title: z.string(),
+  tags: z.array(z.string()).default([]),
+  excerpt: z.string().optional(),
+  url: z.string().url().optional(),
+  body: z.string(),
+});
+
+export type KnowledgeArticle = z.infer<typeof KnowledgeArticleSchema>;
+
+export const ProjectConfigSchema = z.object({
+  server: z.object({
+    name: z.string(),
+    description: z.string(),
+    port: z.number().int().nonnegative().default(8000),
+  }),
+  aiProviders: z.object({
+    defaultModel: z.string(),
+    fallbackModel: z.string().optional(),
+    temperature: z.number().min(0).max(2).default(0.2),
+  }),
+  dataPaths: z.object({
+    tickets: z.string(),
+    knowledgeBase: z.string(),
+  }),
+  governance: z.object({
+    allowTicketUpdates: z.boolean().default(false),
+    auditLogPath: z.string().optional(),
+  }).default({ allowTicketUpdates: false }),
+});
+
+export type ProjectConfig = z.infer<typeof ProjectConfigSchema>;
+
+export interface ToolInvocationContext {
+  ticket: Ticket | null;
+  query: string;
+  projectConfig: ProjectConfig;
+}
+
+export interface ToolResult {
+  type: "text" | "json";
+  content: string | Record<string, unknown>;
+  summary?: string;
+}
+
+export type ToolHandler = (context: ToolInvocationContext) => Promise<ToolResult>;
+
+export interface ToolDefinition {
+  name: string;
+  description: string;
+  handler: ToolHandler;
+  parameters?: z.ZodTypeAny;
+  outputSchema?: z.ZodTypeAny;
+}
+
+export interface WorkflowContext {
+  ticket: Ticket;
+  tools: {
+    invoke(name: string, context: ToolInvocationContext): Promise<ToolResult>;
+  };
+  config: ProjectConfig;
+  artifacts: Map<string, unknown>;
+}
+
+export type WorkflowStep = (context: WorkflowContext) => Promise<void>;
+
+export interface WorkflowDefinition {
+  name: string;
+  description: string;
+  steps: WorkflowStep[];
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,37 @@
+import { config as loadEnv } from "dotenv";
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { loadProjectConfig } from "./config/projectConfig.js";
+import { createToolRegistry } from "./tools/toolRegistry.js";
+import { createWorkflowRegistry } from "./workflows/workflowRegistry.js";
+import { createServer } from "./server/createServer.js";
+import { logger } from "./utils/logger.js";
+
+loadEnv();
+
+export async function bootstrap(): Promise<void> {
+  const projectConfig = loadProjectConfig();
+  const toolRegistry = createToolRegistry({ projectConfig });
+  const workflowRegistry = createWorkflowRegistry({ projectConfig, toolRegistry });
+  const server = createServer({ config: projectConfig, toolRegistry, workflowRegistry });
+
+  await server.start();
+
+  if (process.env.DEMO_WORKFLOW && process.env.DEMO_TICKET_ID) {
+    const artifacts = await server.runWorkflow(process.env.DEMO_WORKFLOW, process.env.DEMO_TICKET_ID);
+    logger.info({ artifacts: Object.fromEntries(artifacts.entries()) }, "Demo workflow execution completed");
+  }
+}
+
+const isMainModule = (() => {
+  const modulePath = fileURLToPath(import.meta.url);
+  const scriptPath = process.argv[1] ? resolve(process.argv[1]) : undefined;
+  return scriptPath ? resolve(modulePath) === scriptPath : false;
+})();
+
+if (isMainModule) {
+  bootstrap().catch((error) => {
+    logger.error({ err: error }, "Failed to start MCP server runtime");
+    process.exit(1);
+  });
+}

--- a/src/server/createServer.ts
+++ b/src/server/createServer.ts
@@ -1,0 +1,92 @@
+import { ProjectConfig, Ticket } from "../domain/types.js";
+import { logger } from "../utils/logger.js";
+import { ToolRegistry } from "../tools/toolRegistry.js";
+import { WorkflowRegistry } from "../workflows/workflowRegistry.js";
+import { TicketingService } from "../services/ticketingService.js";
+
+export interface ServerRuntime {
+  start(): Promise<void>;
+  stop(): Promise<void>;
+  runWorkflow(workflowName: string, ticketId: string): Promise<Map<string, unknown>>;
+  listWorkflows(): string[];
+  listTools(): string[];
+}
+
+interface CreateServerOptions {
+  config: ProjectConfig;
+  toolRegistry: ToolRegistry;
+  workflowRegistry: WorkflowRegistry;
+}
+
+export function createServer({ config, toolRegistry, workflowRegistry }: CreateServerOptions): ServerRuntime {
+  const ticketService = new TicketingService(config.dataPaths.tickets);
+
+  async function start(): Promise<void> {
+    logger.info(
+      {
+        serverName: config.server.name,
+        tools: toolRegistry.list().map((tool) => tool.name),
+        workflows: workflowRegistry.list().map((workflow) => workflow.name),
+      },
+      "Starting MCP server runtime",
+    );
+
+    await attemptSdkBootstrap();
+  }
+
+  async function stop(): Promise<void> {
+    logger.info("Shutting down MCP server runtime");
+  }
+
+  async function runWorkflow(workflowName: string, ticketId: string): Promise<Map<string, unknown>> {
+    const ticket = resolveTicket(ticketId);
+    const artifacts = await workflowRegistry.run(workflowName, ticket);
+    logger.info({ workflowName, ticketId }, "Workflow execution completed");
+    return artifacts;
+  }
+
+  function listWorkflows(): string[] {
+    return workflowRegistry.list().map((workflow) => workflow.name);
+  }
+
+  function listTools(): string[] {
+    return toolRegistry.list().map((tool) => tool.name);
+  }
+
+  function resolveTicket(ticketId: string): Ticket {
+    const ticket = ticketService.findTicket(ticketId);
+
+    if (!ticket) {
+      throw new Error(`Ticket ${ticketId} not found in local data set.`);
+    }
+
+    return ticket;
+  }
+
+  return {
+    start,
+    stop,
+    runWorkflow,
+    listWorkflows,
+    listTools,
+  };
+}
+
+async function attemptSdkBootstrap(): Promise<void> {
+  try {
+    const sdkModule = (await import("@modelcontextprotocol/sdk")) as Record<string, unknown>;
+
+    if (typeof sdkModule?.Server === "function") {
+      logger.info(
+        "Detected '@modelcontextprotocol/sdk'. Wire server registration logic to Server class in createServer.ts.",
+      );
+    } else {
+      logger.debug("@modelcontextprotocol/sdk module does not expose a Server constructor in this environment.");
+    }
+  } catch (error) {
+    logger.debug(
+      { error: (error as Error).message },
+      "@modelcontextprotocol/sdk not installed. Using lightweight runtime stub instead.",
+    );
+  }
+}

--- a/src/services/knowledgeBaseService.ts
+++ b/src/services/knowledgeBaseService.ts
@@ -1,0 +1,52 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { KnowledgeArticle, KnowledgeArticleSchema } from "../domain/types.js";
+import { logger } from "../utils/logger.js";
+
+export class KnowledgeBaseService {
+  private cache: KnowledgeArticle[] | null = null;
+
+  constructor(private readonly dataPath: string) {}
+
+  private loadFromDisk(): KnowledgeArticle[] {
+    const absolutePath = resolve(process.cwd(), this.dataPath);
+    const raw = readFileSync(absolutePath, "utf-8");
+    const parsed = JSON.parse(raw) as unknown;
+
+    const result = KnowledgeArticleSchema.array().safeParse(parsed);
+
+    if (!result.success) {
+      logger.error({ issues: result.error.issues }, "Failed to load knowledge base articles");
+      throw new Error("Knowledge base validation failed");
+    }
+
+    logger.debug({ count: result.data.length }, "Loaded knowledge base articles");
+    return result.data;
+  }
+
+  private ensureCache(): KnowledgeArticle[] {
+    if (!this.cache) {
+      this.cache = this.loadFromDisk();
+    }
+
+    return this.cache;
+  }
+
+  public search(query: string, limit = 5): KnowledgeArticle[] {
+    const articles = this.ensureCache();
+    const terms = query.toLowerCase().split(/\W+/).filter(Boolean);
+
+    const scored = articles
+      .map((article) => {
+        const haystack = `${article.title} ${article.body} ${article.tags.join(" ")}`.toLowerCase();
+        const score = terms.reduce((acc, term) => (haystack.includes(term) ? acc + 1 : acc), 0);
+        return { article, score };
+      })
+      .filter((item) => item.score > 0)
+      .sort((a, b) => b.score - a.score)
+      .slice(0, limit)
+      .map((item) => item.article);
+
+    return scored;
+  }
+}

--- a/src/services/ticketingService.ts
+++ b/src/services/ticketingService.ts
@@ -1,0 +1,61 @@
+import { readFileSync, writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { Ticket, TicketSchema } from "../domain/types.js";
+import { logger } from "../utils/logger.js";
+
+export class TicketingService {
+  private cache: Ticket[] | null = null;
+  private readonly absolutePath: string;
+
+  constructor(private readonly dataPath: string) {
+    this.absolutePath = resolve(process.cwd(), dataPath);
+  }
+
+  private loadFromDisk(): Ticket[] {
+    const raw = readFileSync(this.absolutePath, "utf-8");
+    const parsed = JSON.parse(raw) as unknown;
+    const result = TicketSchema.array().safeParse(parsed);
+
+    if (!result.success) {
+      logger.error({ issues: result.error.issues }, "Failed to load ticket data");
+      throw new Error("Ticket data validation failed");
+    }
+
+    logger.debug({ count: result.data.length }, "Loaded tickets from disk");
+    return result.data;
+  }
+
+  private ensureCache(): Ticket[] {
+    if (!this.cache) {
+      this.cache = this.loadFromDisk();
+    }
+
+    return this.cache;
+  }
+
+  listTickets(): Ticket[] {
+    return this.ensureCache();
+  }
+
+  findTicket(id: string): Ticket | undefined {
+    return this.ensureCache().find((ticket) => ticket.id === id);
+  }
+
+  updateTicket(updatedTicket: Ticket): void {
+    const tickets = this.ensureCache();
+    const index = tickets.findIndex((ticket) => ticket.id === updatedTicket.id);
+
+    if (index === -1) {
+      throw new Error(`Ticket ${updatedTicket.id} not found`);
+    }
+
+    tickets[index] = {
+      ...tickets[index],
+      ...updatedTicket,
+      updatedAt: new Date().toISOString(),
+    };
+
+    writeFileSync(this.absolutePath, JSON.stringify(tickets, null, 2));
+    logger.info({ ticketId: updatedTicket.id }, "Persisted ticket update to disk");
+  }
+}

--- a/src/tools/knowledgeBaseTool.ts
+++ b/src/tools/knowledgeBaseTool.ts
@@ -1,0 +1,65 @@
+import { z } from "zod";
+import { ProjectConfig, ToolDefinition, ToolInvocationContext, ToolResult } from "../domain/types.js";
+import { KnowledgeBaseService } from "../services/knowledgeBaseService.js";
+
+const KnowledgeToolParameters = z.object({
+  query: z.string().min(2, "Provide a more descriptive query"),
+  limit: z.number().int().min(1).max(10).default(3),
+});
+
+interface KnowledgeToolDependencies {
+  projectConfig: ProjectConfig;
+}
+
+export function createKnowledgeBaseTool({ projectConfig }: KnowledgeToolDependencies): ToolDefinition {
+  const service = new KnowledgeBaseService(projectConfig.dataPaths.knowledgeBase);
+
+  async function handler(context: ToolInvocationContext): Promise<ToolResult> {
+    const params = interpretParameters(context);
+    const results = service.search(params.query, params.limit);
+
+    if (results.length === 0) {
+      return {
+        type: "text",
+        content: "No knowledge base matches found for the provided query.",
+      };
+    }
+
+    return {
+      type: "json",
+      content: {
+        query: params.query,
+        results: results.map((article) => ({
+          id: article.id,
+          title: article.title,
+          excerpt: article.excerpt,
+          url: article.url,
+          tags: article.tags,
+        })),
+      },
+      summary: `Retrieved ${results.length} potential knowledge base matches.`,
+    };
+  }
+
+  return {
+    name: "knowledge_base_search",
+    description: "Retrieve relevant FreshDesk knowledge base articles for a user question or ticket context.",
+    handler,
+    parameters: KnowledgeToolParameters,
+  };
+}
+
+function interpretParameters(context: ToolInvocationContext) {
+  const raw = context.query.trim();
+
+  if (raw.startsWith("{")) {
+    try {
+      const parsed = JSON.parse(raw) as Record<string, unknown>;
+      return KnowledgeToolParameters.parse(parsed);
+    } catch (error) {
+      return KnowledgeToolParameters.parse({ query: context.query });
+    }
+  }
+
+  return KnowledgeToolParameters.parse({ query: context.query });
+}

--- a/src/tools/ticketingTool.ts
+++ b/src/tools/ticketingTool.ts
@@ -1,0 +1,121 @@
+import { z } from "zod";
+import { ProjectConfig, ToolDefinition, ToolInvocationContext, ToolResult } from "../domain/types.js";
+import { TicketingService } from "../services/ticketingService.js";
+
+const TicketingToolParameters = z.object({
+  action: z.enum(["list_open", "get_details", "update_status"]).default("get_details"),
+  ticketId: z.string().optional(),
+  status: z.enum(["open", "pending", "resolved", "closed"]).optional(),
+});
+
+interface TicketingToolDependencies {
+  projectConfig: ProjectConfig;
+}
+
+export function createTicketingTool({ projectConfig }: TicketingToolDependencies): ToolDefinition {
+  const service = new TicketingService(projectConfig.dataPaths.tickets);
+
+  async function handler(context: ToolInvocationContext): Promise<ToolResult> {
+    const params = interpretParameters(context);
+
+    switch (params.action) {
+      case "list_open": {
+        const openTickets = service
+          .listTickets()
+          .filter((ticket) => ticket.status === "open" || ticket.status === "pending")
+          .map((ticket) => ({ id: ticket.id, subject: ticket.subject, priority: ticket.priority }));
+
+        return {
+          type: "json",
+          content: { tickets: openTickets },
+          summary: `Identified ${openTickets.length} open or pending tickets awaiting action.`,
+        };
+      }
+      case "get_details": {
+        const ticketId = params.ticketId ?? context.ticket?.id;
+
+        if (!ticketId) {
+          return {
+            type: "text",
+            content: "Ticket ID is required to retrieve ticket details.",
+          };
+        }
+
+        const ticket = service.findTicket(ticketId);
+
+        if (!ticket) {
+          return {
+            type: "text",
+            content: `No ticket found with ID ${ticketId}.`,
+          };
+        }
+
+        return {
+          type: "json",
+          content: ticket,
+          summary: `Loaded ticket ${ticketId} for downstream analysis steps.`,
+        };
+      }
+      case "update_status": {
+        if (!projectConfig.governance.allowTicketUpdates) {
+          return {
+            type: "text",
+            content: "Ticket updates are disabled in the current governance configuration.",
+          };
+        }
+
+        const ticketId = params.ticketId ?? context.ticket?.id;
+        if (!ticketId || !params.status) {
+          return {
+            type: "text",
+            content: "Ticket ID and target status are required to update a ticket.",
+          };
+        }
+
+        const ticket = service.findTicket(ticketId);
+        if (!ticket) {
+          return {
+            type: "text",
+            content: `Cannot update ticket ${ticketId} because it does not exist in the offline data set.`,
+          };
+        }
+
+        service.updateTicket({ ...ticket, status: params.status });
+        return {
+          type: "text",
+          content: `Ticket ${ticketId} updated to status '${params.status}'.`,
+        };
+      }
+      default:
+        return {
+          type: "text",
+          content: "Unsupported ticketing action requested.",
+        };
+    }
+  }
+
+  return {
+    name: "ticketing_operations",
+    description: "Inspect or update FreshDesk-style tickets used within automated MCP workflows.",
+    handler,
+    parameters: TicketingToolParameters,
+  };
+}
+
+function interpretParameters(context: ToolInvocationContext) {
+  const raw = context.query.trim();
+
+  if (raw.length === 0) {
+    return TicketingToolParameters.parse({ action: "get_details", ticketId: context.ticket?.id });
+  }
+
+  try {
+    const parsed = JSON.parse(raw) as Record<string, unknown>;
+    return TicketingToolParameters.parse({ ticketId: context.ticket?.id, ...parsed });
+  } catch (error) {
+    return TicketingToolParameters.parse({
+      action: raw.includes("list") ? "list_open" : "get_details",
+      ticketId: context.ticket?.id,
+    });
+  }
+}

--- a/src/tools/toolRegistry.ts
+++ b/src/tools/toolRegistry.ts
@@ -1,0 +1,62 @@
+import { ProjectConfig, ToolDefinition, ToolInvocationContext, ToolResult } from "../domain/types.js";
+import { logger } from "../utils/logger.js";
+import { createKnowledgeBaseTool } from "./knowledgeBaseTool.js";
+import { createTicketingTool } from "./ticketingTool.js";
+
+export interface ToolRegistry {
+  register(tool: ToolDefinition): void;
+  list(): ToolDefinition[];
+  invoke(name: string, context: ToolInvocationContext): Promise<ToolResult>;
+}
+
+export interface ToolRegistryDependencies {
+  projectConfig: ProjectConfig;
+}
+
+export function createToolRegistry({ projectConfig }: ToolRegistryDependencies): ToolRegistry {
+  const registry = new Map<string, ToolDefinition>();
+
+  const baseTools = [
+    createKnowledgeBaseTool({ projectConfig }),
+    createTicketingTool({ projectConfig }),
+  ];
+
+  for (const tool of baseTools) {
+    registry.set(tool.name, tool);
+  }
+
+  function register(tool: ToolDefinition) {
+    if (registry.has(tool.name)) {
+      logger.warn({ tool: tool.name }, "Overwriting existing tool registration");
+    }
+
+    registry.set(tool.name, tool);
+  }
+
+  async function invoke(name: string, context: ToolInvocationContext): Promise<ToolResult> {
+    const tool = registry.get(name);
+
+    if (!tool) {
+      throw new Error(`Tool '${name}' is not registered`);
+    }
+
+    logger.debug({ tool: name, query: context.query }, "Invoking MCP tool");
+    const result = await tool.handler(context);
+
+    if (tool.outputSchema) {
+      tool.outputSchema.parse(result.content);
+    }
+
+    return result;
+  }
+
+  function list(): ToolDefinition[] {
+    return Array.from(registry.values());
+  }
+
+  return {
+    register,
+    list,
+    invoke,
+  };
+}

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -1,0 +1,9 @@
+import pino from "pino";
+
+export const logger = pino({
+  name: "mcp-freshdesk",
+  level: process.env.LOG_LEVEL ?? "info",
+  transport: process.env.NODE_ENV === "development"
+    ? { target: "pino-pretty", options: { colorize: true } }
+    : undefined,
+});

--- a/src/workflows/triageWorkflow.ts
+++ b/src/workflows/triageWorkflow.ts
@@ -1,0 +1,36 @@
+import { WorkflowDefinition, WorkflowStep } from "../domain/types.js";
+
+export function createTriageWorkflow(): WorkflowDefinition {
+  const steps: WorkflowStep[] = [gatherContextStep, recommendationStep];
+
+  return {
+    name: "ticket_triage",
+    description:
+      "Analyze an incoming support ticket, retrieve relevant institutional knowledge, and propose a resolution plan.",
+    steps,
+  };
+}
+
+const gatherContextStep: WorkflowStep = async (context) => {
+  const knowledgeResult = await context.tools.invoke("knowledge_base_search", {
+    ticket: context.ticket,
+    query: `${context.ticket.subject}\n${context.ticket.description}`,
+    projectConfig: context.config,
+  });
+
+  context.artifacts.set("knowledgeResult", knowledgeResult);
+};
+
+const recommendationStep: WorkflowStep = async (context) => {
+  const knowledgeResult = context.artifacts.get("knowledgeResult");
+
+  context.artifacts.set(
+    "triageRecommendation",
+    {
+      suggestedStatus: "pending",
+      justification:
+        "Review recommended knowledge base articles and tailor a user response. Escalate if no match is adequate.",
+      knowledgeResult,
+    },
+  );
+};

--- a/src/workflows/workflowRegistry.ts
+++ b/src/workflows/workflowRegistry.ts
@@ -1,0 +1,65 @@
+import { ProjectConfig, Ticket, WorkflowDefinition } from "../domain/types.js";
+import { logger } from "../utils/logger.js";
+import { ToolRegistry } from "../tools/toolRegistry.js";
+import { createTriageWorkflow } from "./triageWorkflow.js";
+
+export interface WorkflowRegistry {
+  register(workflow: WorkflowDefinition): void;
+  list(): WorkflowDefinition[];
+  run(workflowName: string, ticket: Ticket): Promise<Map<string, unknown>>;
+}
+
+interface WorkflowRegistryDependencies {
+  projectConfig: ProjectConfig;
+  toolRegistry: ToolRegistry;
+}
+
+export function createWorkflowRegistry({ projectConfig, toolRegistry }: WorkflowRegistryDependencies): WorkflowRegistry {
+  const workflows = new Map<string, WorkflowDefinition>();
+
+  const defaultWorkflows = [createTriageWorkflow()];
+  for (const workflow of defaultWorkflows) {
+    workflows.set(workflow.name, workflow);
+  }
+
+  function register(workflow: WorkflowDefinition) {
+    if (workflows.has(workflow.name)) {
+      logger.warn({ workflow: workflow.name }, "Overwriting existing workflow definition");
+    }
+
+    workflows.set(workflow.name, workflow);
+  }
+
+  async function run(workflowName: string, ticket: Ticket): Promise<Map<string, unknown>> {
+    const workflow = workflows.get(workflowName);
+
+    if (!workflow) {
+      throw new Error(`Workflow '${workflowName}' is not registered.`);
+    }
+
+    const artifacts = new Map<string, unknown>();
+
+    for (const step of workflow.steps) {
+      await step({
+        ticket,
+        tools: {
+          invoke: (toolName, ctx) => toolRegistry.invoke(toolName, ctx),
+        },
+        config: projectConfig,
+        artifacts,
+      });
+    }
+
+    return artifacts;
+  }
+
+  function list(): WorkflowDefinition[] {
+    return Array.from(workflows.values());
+  }
+
+  return {
+    register,
+    list,
+    run,
+  };
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ES2022",
+    "moduleResolution": "node",
+    "outDir": "dist",
+    "rootDir": "src",
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "allowSyntheticDefaultImports": true,
+    "types": ["node"]
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
## Summary
- scaffold a TypeScript-based MCP server runtime with configuration loading, registries, and logging utilities
- add placeholder knowledge base and ticketing tools plus workflow orchestration and file-backed services
- document repository layout, provide sample data, and outline architectural extension prompts

## Testing
- not run (node dependencies not installed in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68c896c9ceb8832bbeb73d6795bedc6f